### PR TITLE
import from react-motion/lib to reduce bundle size

### DIFF
--- a/src/RouteTransition.jsx
+++ b/src/RouteTransition.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes, cloneElement, createElement } from 'react';
-import { TransitionMotion } from 'react-motion';
+import TransitionMotion from 'react-motion/lib/TransitionMotion';
 
 import ensureSpring from './ensureSpring';
 

--- a/src/ensureSpring.js
+++ b/src/ensureSpring.js
@@ -1,4 +1,4 @@
-import { spring } from 'react-motion';
+import spring from 'react-motion/lib/spring';
 
 export default function ensureSpring(styles) {
   return Object.keys(styles).reduce((acc, key) => {

--- a/src/presets.js
+++ b/src/presets.js
@@ -1,4 +1,4 @@
-import { spring } from 'react-motion';
+import spring from 'react-motion/lib/spring';
 
 const fadeConfig = { stiffness: 200, damping: 22 };
 const popConfig = { stiffness: 360, damping: 25 };


### PR DESCRIPTION
This change could make the lib/react-router-transition.js reduce ~20KB