### PR TITLE
Remove react as dependency (Use as peer/dev)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-motion": "^0.5.0",
     "react-router-dom": "^4.1.1"
@@ -78,6 +77,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "prettier": "^1.3.1",
+    "react": "^15.6.1",
     "webpack": "^2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   },
   "homepage": "https://github.com/maisano/react-router-transition#readme",
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react-dom": "^15.6.1",
     "react-motion": "^0.5.0",
     "react-router-dom": "^4.1.1"
   },
@@ -78,6 +78,7 @@
     "babel-preset-react": "^6.24.1",
     "prettier": "^1.3.1",
     "react": "^15.6.1",
+    "react-dom": "^15.6.1",
     "webpack": "^2.6.1"
   }
 }


### PR DESCRIPTION
Having react as a dependency potentially causes two copies of react when using this dependency