### PR TITLE
Fix #102 and prepare for react-router v4.4.0 onwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,12 @@ Painless transitions for React Router, powered by React Motion. [Example site](h
 
 ### Installation
 
-`npm install --save react-router-transition`
+`npm install --save react-router-transition react-router-dom`
 
 ### Example Usage
 ```jsx
-import Router from 'react-router-dom/BrowserRouter';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { AnimatedSwitch } from 'react-router-transition';
-import Route from 'react-router-dom/Route';
 
 export default () => (
   <Router>

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   "homepage": "https://github.com/maisano/react-router-transition#readme",
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react-dom": "^15.0.0 || ^16.0.0",
+    "react-router-dom": "^4.1.1"
   },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react-motion": "^0.5.0",
-    "react-router-dom": "^4.1.1"
+    "react-motion": "^0.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/AnimatedRoute.js
+++ b/src/AnimatedRoute.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import Route from 'react-router-dom/Route';
-import matchPath from 'react-router-dom/matchPath';
+import { Route, matchPath } from 'react-router-dom';
 
 import RouteTransition from './RouteTransition';
 

--- a/src/AnimatedSwitch.js
+++ b/src/AnimatedSwitch.js
@@ -1,7 +1,5 @@
 import React from 'react';
-import Route from 'react-router-dom/Route';
-import Switch from 'react-router-dom/Switch';
-import matchPath from 'react-router-dom/matchPath';
+import { Route, Switch, matchPath } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import RouteTransition from './RouteTransition';


### PR DESCRIPTION
From #102, `react-router` v4.4.0 changes [how you should import the library](https://github.com/ReactTraining/react-router/releases/tag/v4.4.0-beta.1). 

This PR fixes that problem and update the docs to reflect the changes