### PR TITLE
Support render for AnimatedRoute

### DIFF
--- a/src/AnimatedRoute.js
+++ b/src/AnimatedRoute.js
@@ -12,7 +12,7 @@ function getKey({ pathname }, path, exact) {
   return matchPath(pathname, { exact, path }) ? 'match' : 'no-match';
 }
 
-const AnimatedRoute = ({ component, path, exact, ...routeTransitionProps }) => (
+const AnimatedRoute = ({ render, component, path, exact, ...routeTransitionProps }) => (
   <Route
     render={({ location, match }) => (
       <RouteTransition {...routeTransitionProps}>
@@ -22,6 +22,7 @@ const AnimatedRoute = ({ component, path, exact, ...routeTransitionProps }) => (
           exact={exact}
           location={location}
           component={component}
+          render={render}
         />
       </RouteTransition>
     )}


### PR DESCRIPTION
### First, thanks for the package.
Thanks for the really useful package allowing transitions via routes and more!

## The Fix
Simply added the render prop into the codebase. 
[React Router](https://github.com/ReactTraining/react-router) uses a ternary to check for the render key if component key is not used.

## The problem
The project I am putting this into does not use `component` in <route/> we instead use `render`

Non essential information related to the pr can be found here:
https://github.com/dimmitt/non-essential-information-for-react-router-transition-pr/tree/master