### PR TITLE
Exact/Default routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,16 +163,21 @@ function getMatchedRoute(children, { pathname }) {
 
   for (let i = 0; i < childrenArray.length; i++) {
     const child = childrenArray[i];
-    const matches = matchPath(pathname, {
-      exact: child.props.exact,
-      path: child.props.path,
-    });
-
+    var matches=null;
+    try{
+      matches = matchPath(pathname, {
+        exact: child.props.exact,
+        path: child.props.path,
+      });
+    }
+    catch(e)
+    {
+      matches=null;
+    }
     if (matches) {
       return child;
     }
   }
-
   return NO_MATCH;
 }
 


### PR DESCRIPTION
the plugin threw an error if a route with exact property doesn't exist. also, throws error if using default routes

fixed both cases.